### PR TITLE
Read configuration paths from environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Tesseract CLI 실행 파일 경로 (예: C:\\Program Files\\Tesseract-OCR\\tesseract.exe)
+TESSERACT_CMD=/usr/bin/tesseract
+# Vertex AI 서비스 계정 JSON 키 파일 경로
+VERTEX_CREDENTIALS=./config/vertex-service-account.json

--- a/README_ko.md
+++ b/README_ko.md
@@ -16,6 +16,12 @@ Ultimate Automation System v3은 다중 에이전트 기반 자동화 파이프�
 - 환경 변수는 UAS_ 접두사와 __ 구분자를 사용합니다. 예: UAS_AI__TEMPERATURE=0.3.
 - API 키와 같은 비밀 값은 환경 변수나 시크립 매니저로 주입하고 저장소에 커밋하지 말아주세요.
 
+### 설정 계층 (default→local→env→UI)
+1. **default**: 저장소에 포함된 config/default.yaml이 기본값을 제공합니다.
+2. **local**: config/local.yaml(존재할 경우)이 default 값을 덮어씁니다. 예시는 config/local.yaml.example을 참고하세요.
+3. **env**: .env 또는 시스템 환경 변수(TESSERACT_CMD, VERTEX_CREDENTIALS, UAS_*)가 YAML 값을 재정의합니다.
+4. **UI**: 실행 중 GUI에서 변경한 값은 메모리에만 적용되며 종료 시 초기화됩니다.
+
 ## 5분 체험
 1. examples/sample_request_basic.json 파일을 열어 요청 페이로드를 준비하세요.
 2. 메인 엔트리 포인트 실행: python src/ultimate_automation_system.py --config config/local.yaml.
@@ -38,3 +44,8 @@ Ultimate Automation System v3은 다중 에이전트 기반 자동화 파이프�
 - **출력 인코딩 깔끔**: UTF-8을 지원하는 터미널인지 확인하고 logs/latest.log에서 디코딩 힌트를 확인하세요.
 - **환경 설정이 적용되지 않음**: 환경 변수 알파른과 config/local.yaml이 기본 프로필을 상속하는지 검토하세요.
 - **파이프라인 중단**: 실행 전 scripts/dev.ps1 -Task lint를 통해 검증 오류를 사전에 발견하세요.
+
+## OS별 주의사항
+- **Windows**: Tesseract 경로에 공백이 포함되면 따옴표로 감싸거나 환경 변수 TESSERACT_CMD에 전체 경로를 지정하세요.
+- **macOS**: `brew install tesseract`로 설치한 후 `/opt/homebrew/bin`이 PATH에 포함되었는지 확인하고 필요 시 .env에 TESSERACT_CMD를 명시하세요.
+- **Linux**: 패키지 관리자(`apt install tesseract-ocr` 등)로 설치 후 서비스 계정 키 파일 권한을 `chmod 600`으로 제한해 누출을 방지하세요.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,5 +1,5 @@
 system:
-  version: 2.0.0
+  version: 3.0.0
   encoding: utf-8
   debug_mode: false
   test_mode: false
@@ -163,7 +163,7 @@ ocr:
     threshold: 128
     dpi: 300
   tesseract:
-    command: E:/tesseract/tesseract.exe
+    command: ${TESSERACT_CMD}
     psm: 3
     oem: 3
     config: --oem 3 --psm 3 -l kor+eng
@@ -176,7 +176,7 @@ ai:
   vertex:
     project_id: jadong-471919
     location: us-central1
-    credentials_path: E:/VSC/EVEREiThing/ultimate_automation_system_v3/ultimate_automation_system_v3/jadong-471919-29a5670ace12.json
+    credentials_path: ${VERTEX_CREDENTIALS}
     model:
       name: gemini-2.5-pro
       temperature: 0.3
@@ -205,7 +205,7 @@ ai:
     must_include: []
 gui:
   window:
-    title: Ultimate Automation System v2.0
+    title: Ultimate Automation System v3.0.0
     size: 1400x800
     min_size: 1200x600
     resizable: true

--- a/config/local.yaml.example
+++ b/config/local.yaml.example
@@ -1,0 +1,7 @@
+# config/default.yaml에서 필요한 값만 복사해 덮어쓰세요.
+ocr:
+  tesseract:
+    command: ${TESSERACT_CMD}  # Tesseract 실행 파일 경로 (환경 변수로 주입)
+ai:
+  vertex:
+    credentials_path: ${VERTEX_CREDENTIALS}  # Vertex AI 서비스 계정 JSON 키 경로

--- a/src/modules/ai_generator.py
+++ b/src/modules/ai_generator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 from pathlib import Path
 from typing import Any, Dict, List
@@ -27,10 +28,12 @@ class AIGenerator:
         self.template = Path(self.c["ai"]["prompt"]["template_file"]).read_text(encoding="utf-8")
 
     def _configure_tesseract(self) -> None:
+        env_cmd = os.environ.get("TESSERACT_CMD")
         try:
             cmd = self.c.get("ocr", {}).get("tesseract", {}).get("command")
         except AttributeError:
             cmd = None
+        cmd = env_cmd or cmd
         if not cmd:
             return
         path = Path(cmd).expanduser()
@@ -64,7 +67,8 @@ class AIGenerator:
             raise ValueError(f"Vertex AI 설정값이 누락되었습니다: {', '.join(missing)}")
 
         credentials = None
-        credentials_path = vertex_conf.get("credentials_path")
+        env_credentials = os.environ.get("VERTEX_CREDENTIALS")
+        credentials_path = env_credentials or vertex_conf.get("credentials_path")
         if credentials_path:
             cred_path = Path(credentials_path).expanduser()
             if cred_path.exists():

--- a/src/ultimate_automation_system.py
+++ b/src/ultimate_automation_system.py
@@ -144,7 +144,12 @@ class UltimateAutomationSystem:
         self.model_name_var = tk.StringVar(value=self.config.get("ai", {}).get("vertex", {}).get("model", {}).get("name", ""))
         ttk.Entry(self.set_tab, textvariable=self.model_name_var, width=60).grid(row=3, column=1, sticky="w", padx=6, pady=6)
         ttk.Label(self.set_tab, text="Credentials path:").grid(row=4, column=0, sticky="e", padx=6, pady=6)
-        self.credentials_path_var = tk.StringVar(value=self.config.get("ai", {}).get("vertex", {}).get("credentials_path", ""))
+        default_credentials_path = (
+            os.environ.get("VERTEX_CREDENTIALS")
+            or os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+            or self.config.get("ai", {}).get("vertex", {}).get("credentials_path", "")
+        )
+        self.credentials_path_var = tk.StringVar(value=default_credentials_path)
         ttk.Entry(self.set_tab, textvariable=self.credentials_path_var, width=60).grid(row=4, column=1, sticky="w", padx=6, pady=6)
         ttk.Button(self.set_tab, text="적용", command=self.apply_settings).grid(row=4, column=2, padx=6, pady=6)
 
@@ -338,7 +343,7 @@ class UltimateAutomationSystem:
         location = self.location_var.get().strip()
         model_name = self.model_name_var.get().strip()
         credentials_input = self.credentials_path_var.get().strip()
-        credential_env = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+        credential_env = os.environ.get("VERTEX_CREDENTIALS") or os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
         if prov != "vertex":
             issues.append("현재 빌드는 Vertex AI Gemini만 지원합니다.")
         if not project:
@@ -352,7 +357,7 @@ class UltimateAutomationSystem:
             if not cred_path.exists():
                 issues.append(f"서비스 계정 키 파일을 찾을 수 없습니다: {cred_path}")
         elif not credential_env:
-            issues.append("서비스 계정 키 경로를 입력하거나 GOOGLE_APPLICATION_CREDENTIALS 환경변수를 설정해주세요.")
+            issues.append("서비스 계정 키 경로를 입력하거나 VERTEX_CREDENTIALS/GOOGLE_APPLICATION_CREDENTIALS 환경변수를 설정해주세요.")
         if missing:
             issues.append(f"템플릿 이미지 없음: {missing}")
         color = "초록(정상)" if not issues else "빨강(문제)"


### PR DESCRIPTION
## Summary
- update the bundled configuration to version 3.0.0 and align the GUI title
- read Tesseract and Vertex credential paths from environment variables with new sample config files
- document the configuration layering along with OS-specific setup notes in the Korean README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d3444971b08331928071e17a04085e