### PR TITLE
feat: enforce cold email schema validation

### DIFF
--- a/assets/templates/cold_email_prompt.txt
+++ b/assets/templates/cold_email_prompt.txt
@@ -19,10 +19,8 @@
 
 [INPUT FIELDS]
 - 제품명: {product_name}
-- 브랜드: {brand}
-- 특징: {features}
-- 리뷰 요약: {review_summary}
-- 언어: {language}
+- 핵심 특징: {unique_features}
+- 요청 행동: {call_to_action}
 
 [REQUIREMENTS]
 - JSON meta와 본문 사이에 빈 줄 1개

--- a/src/modules/email_schema.py
+++ b/src/modules/email_schema.py
@@ -1,0 +1,53 @@
+"""Schema definitions for cold email generation outputs."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+REQUIRED_EMAIL_META_KEYS = ("product_name", "unique_features", "call_to_action")
+
+
+class ColdEmailMeta(BaseModel):
+    """Structured representation of the metadata block expected from the LLM."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    product_name: str = Field(..., min_length=1)
+    unique_features: List[str]
+    call_to_action: str = Field(..., min_length=1)
+
+    @field_validator("product_name", "call_to_action", mode="before")
+    @classmethod
+    def _strip_string(cls, value: str) -> str:
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                raise ValueError("값은 비어 있을 수 없습니다")
+            return stripped
+        raise TypeError("문자열 값이어야 합니다")
+
+    @field_validator("unique_features", mode="before")
+    @classmethod
+    def _normalise_features(cls, value: object) -> List[str]:
+        if isinstance(value, str):
+            items: Iterable[str] = value.splitlines() or [value]
+        elif isinstance(value, Iterable):
+            items = [str(item) for item in value]
+        else:  # pragma: no cover - defensive branch
+            raise TypeError("unique_features는 문자열 또는 문자열 목록이어야 합니다")
+
+        normalised = [item.strip() for item in items if str(item).strip()]
+        if not normalised:
+            raise ValueError("unique_features는 최소 1개 이상의 항목이 필요합니다")
+        return normalised
+
+    @model_validator(mode="after")
+    def _ensure_unique_features(self) -> "ColdEmailMeta":
+        if not self.unique_features:
+            raise ValueError("unique_features는 비어 있을 수 없습니다")
+        return self
+
+
+__all__ = ["ColdEmailMeta", "REQUIRED_EMAIL_META_KEYS"]

--- a/tests/test_ai_generator.py
+++ b/tests/test_ai_generator.py
@@ -10,7 +10,9 @@ from src.modules.ai_generator import AIGenerator
 @pytest.fixture
 def vertex_config(tmp_path: Path):
     template = tmp_path / "template.md"
-    template.write_text("{product_name}", encoding="utf-8")
+    template.write_text(
+        "{product_name}\n{unique_features}\n{call_to_action}", encoding="utf-8"
+    )
     return {
         "ai": {
             "provider": "vertex",

--- a/tests/test_email_schema.py
+++ b/tests/test_email_schema.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from src.modules.email_schema import ColdEmailMeta
+
+
+def test_cold_email_meta_accepts_valid_payload() -> None:
+    payload = {
+        "product_name": "Ultimate Battery Pack",
+        "unique_features": ["10시간 초고속 충전", "모듈형 확장"],
+        "call_to_action": "데모 미팅 일정을 논의하고 싶습니다.",
+    }
+
+    meta = ColdEmailMeta.model_validate(payload)
+
+    assert meta.product_name == "Ultimate Battery Pack"
+    assert meta.unique_features == ["10시간 초고속 충전", "모듈형 확장"]
+    assert meta.call_to_action == "데모 미팅 일정을 논의하고 싶습니다."
+
+
+def test_cold_email_meta_rejects_missing_required_key() -> None:
+    with pytest.raises(ValidationError):
+        ColdEmailMeta.model_validate(
+            {
+                "product_name": "Ultimate Battery Pack",
+                "unique_features": "10시간 초고속 충전",
+            }
+        )


### PR DESCRIPTION
## Summary
- define a dedicated ColdEmailMeta pydantic schema with required product_name, unique_features, and call_to_action keys
- update the AI generator prompt, validation flow, and template to rely on the unified schema and auto-repair missing keys
- add smoke tests for schema success and failure cases alongside updated generator fixtures

## Testing
- PYTHONPATH=. pytest tests/test_email_schema.py tests/test_ai_generator.py

------
https://chatgpt.com/codex/tasks/task_b_68d34458ca2c83318ac788247ea4d014