### PR TITLE
Update env and local config examples for v3 template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,6 @@
 # 환경 변수 예시 (.env로 복사 후 값 채우기)
-# Windows에서는 경로에 공백이 있을 경우 따옴표로 감싸지 마세요.
-
-# Tesseract 실행 파일 전체 경로 (예: C:\\Program Files\\Tesseract-OCR\\tesseract.exe)
 TESSERACT_CMD=
-
-# Google Cloud 서비스 계정 키 JSON 경로 (Vertex AI 호출용)
+# Google Cloud 서비스 계정 키 JSON 경로(권장)
 GOOGLE_APPLICATION_CREDENTIALS=
-
-# Vertex AI 전용 환경 변수를 별도로 사용 중이라면 함께 지정하세요.
+# (선택) Vertex 전용 변수를 쓰는 환경이라면 함께 지정
 VERTEX_CREDENTIALS=

--- a/config/local.yaml.example
+++ b/config/local.yaml.example
@@ -1,14 +1,15 @@
 # config/default.yaml에서 필요한 키만 복사해 덮어쓰는 예시입니다.
 # 존재하지 않는 키를 추가하면 로딩 시 무시됩니다.
 system:
-  version: 3.0.0  # GUI 타이틀과 동일하게 표시됩니다.
+  version: 3.0.0
 
 ai:
   prompt:
-    template_file: assets/templates/cold_email_prompt.txt  # 사용자 정의 프롬프트 경로
+    template_file: assets/templates/cold_email_prompt.txt
   vertex:
-    credentials_path: ${VERTEX_CREDENTIALS}  # 또는 GOOGLE_APPLICATION_CREDENTIALS 환경 변수를 사용하세요.
+    # GOOGLE_APPLICATION_CREDENTIALS 또는 VERTEX_CREDENTIALS 중 하나 사용
+    credentials_path: ${VERTEX_CREDENTIALS}
 
 ocr:
   tesseract:
-    command: ${TESSERACT_CMD}  # Tesseract 실행 파일 전체 경로
+    command: ${TESSERACT_CMD}


### PR DESCRIPTION
## Summary
- streamline the example `.env` variables to reflect the current recommendations
- refresh `config/local.yaml.example` to match the v3 cold email prompt defaults

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d36776ecf88331b14a7191629eeb8f